### PR TITLE
Add theme toggle

### DIFF
--- a/assets/css/stylev11.css
+++ b/assets/css/stylev11.css
@@ -102,6 +102,19 @@
 
 }
 
+/* Light theme overrides */
+body.light-theme {
+  --jet: hsl(0, 0%, 90%);
+  --onyx: hsl(0, 0%, 95%);
+  --eerie-black-1: hsl(0, 0%, 96%);
+  --eerie-black-2: hsl(0, 0%, 98%);
+  --smoky-black: hsl(0, 0%, 100%);
+  --white-1: hsl(0, 0%, 10%);
+  --white-2: hsl(0, 0%, 15%);
+  --light-gray: hsl(0, 0%, 30%);
+  --light-gray-70: hsla(0, 0%, 30%, 0.7);
+}
+
 
 
 

--- a/assets/js/scriptv2.js
+++ b/assets/js/scriptv2.js
@@ -1,11 +1,31 @@
 'use strict';
 
+function initTheme() {
+    const toggleBtn = document.getElementById('theme-toggle');
+    const body = document.body;
+    const stored = localStorage.getItem('theme');
+    if (stored === 'light') {
+        body.classList.add('light-theme');
+        if (toggleBtn) {
+            toggleBtn.querySelector('ion-icon').setAttribute('name', 'sunny-outline');
+        }
+    }
+    if (toggleBtn) {
+        toggleBtn.addEventListener('click', function () {
+            body.classList.toggle('light-theme');
+            const isLight = body.classList.contains('light-theme');
+            localStorage.setItem('theme', isLight ? 'light' : 'dark');
+            toggleBtn.querySelector('ion-icon').setAttribute('name', isLight ? 'sunny-outline' : 'moon-outline');
+        });
+    }
+}
+
 $(document).ready(function() {
     const version = new Date().getTime();
     
     // Load head and navbar sections
     $("#head-placeholder").load("head.html?v=" + version);
-    $("#navbar-placeholder").load("navbar.html?v=" + version);
+    $("#navbar-placeholder").load("navbar.html?v=" + version, initTheme);
 
     // Load sidebar and attach event listener after loading
     $("#sidebar-placeholder").load("sidebar.html", function() {
@@ -121,7 +141,7 @@ document.addEventListener("DOMContentLoaded", function () {
 $(document).ready(function() {
     // Load head and navbar sections
     $("#head-placeholder").load("head.html");
-    $("#navbar-placeholder").load("navbar.html");
+    $("#navbar-placeholder").load("navbar.html", initTheme);
 
     // Load sidebar and attach event listener after loading
     $("#sidebar-placeholder").load("sidebar.html", function() {

--- a/navbar.html
+++ b/navbar.html
@@ -18,6 +18,12 @@
         <button class="navbar-link" data-nav-link>More</button>
       </li>
 
+      <li class="navbar-item">
+        <button class="navbar-link" id="theme-toggle" aria-label="Toggle theme">
+          <ion-icon name="moon-outline"></ion-icon>
+        </button>
+      </li>
+
     </ul>
 
 </nav>


### PR DESCRIPTION
## Summary
- enable optional light theme via CSS variables
- add a theme toggle button to the navbar
- persist user's theme choice in localStorage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6873de00b5b8832fa0ec37dc1738dcf1